### PR TITLE
Refactor GTPv1 marshal & unmarshal functions and remove incorrect length check

### DIFF
--- a/src/gtpv1/gtpc/header.rs
+++ b/src/gtpv1/gtpc/header.rs
@@ -130,114 +130,106 @@ impl Gtpv1Header {
     }
 
     pub fn unmarshal(buffer: &[u8]) -> Result<Self, GTPV1Error> {
-        if buffer.len() >= MIN_HEADER_LENGTH {
-            let mut data = Gtpv1Header::default();
-            let gtp_version = buffer[0] >> 5;
-            let gtp_type = (buffer[0] & 0x10) >> 4;
-            match (gtp_version, gtp_type) {
-                (1, 1) => (),
-                (_, _) => return Err(GTPV1Error::HeaderVersionNotSupported),
-            }
-            data.msgtype = buffer[1];
-            data.length = match u16::from_be_bytes([buffer[2], buffer[3]]) {
-                _s if _s < MIN_HEADER_LENGTH as u16 => return Err(GTPV1Error::HeaderInvalidLength),
-                _ => u16::from_be_bytes([buffer[2], buffer[3]]),
-            };
-            data.teid = u32::from_be_bytes([buffer[4], buffer[5], buffer[6], buffer[7]]);
-            match (
-                (buffer[0] & 0x02) >> 1,
-                buffer[0] & 0x01,
-                (buffer[0] & 0x04) >> 2,
-            ) {
-                (1, 1, 1) => {
-                    if buffer[8..].len() >= 4 {
-                        data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
-                        data.npdu_number = Some(buffer[10]);
-                        match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
-                            Ok(i) => data.extension_headers = Some(i),
-                            Err(j) => return Err(j),
-                        }
-                    } else {
-                        return Err(GTPV1Error::HeaderInvalidLength);
-                    }
-                }
-                (1, 1, 0) => {
-                    if buffer[8..].len() >= 4 {
-                        data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
-                        data.npdu_number = Some(buffer[10]);
-                        data.extension_headers = None;
-                    } else {
-                        return Err(GTPV1Error::HeaderInvalidLength);
-                    }
-                }
-                (1, 0, 0) => {
-                    if buffer[8..].len() >= 4 {
-                        data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
-                        data.npdu_number = None;
-                        data.extension_headers = None;
-                    } else {
-                        return Err(GTPV1Error::HeaderInvalidLength);
-                    }
-                }
-                (1, 0, 1) => {
-                    if buffer[8..].len() >= 4 {
-                        data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
-                        data.npdu_number = None;
-                        match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
-                            Ok(i) => data.extension_headers = Some(i),
-                            Err(j) => return Err(j),
-                        }
-                    } else {
-                        return Err(GTPV1Error::HeaderInvalidLength);
-                    }
-                }
-                (0, 0, 0) => {
-                    data.sequence_number = None;
-                    data.npdu_number = None;
-                    data.extension_headers = None;
-                }
-                (0, 0, 1) => {
-                    if buffer[8..].len() >= 4 {
-                        data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
-                        data.npdu_number = Some(buffer[10]);
-                        match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
-                            Ok(i) => data.extension_headers = Some(i),
-                            Err(j) => return Err(j),
-                        }
-                    } else {
-                        return Err(GTPV1Error::HeaderInvalidLength);
-                    }
-                }
-                (0, 1, 1) => {
-                    if buffer[8..].len() >= 4 {
-                        data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
-                        data.npdu_number = Some(buffer[10]);
-                        match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
-                            Ok(i) => data.extension_headers = Some(i),
-                            Err(j) => return Err(j),
-                        }
-                    } else {
-                        return Err(GTPV1Error::HeaderInvalidLength);
-                    }
-                }
-                (0, 1, 0) => {
-                    if buffer[8..].len() >= 4 {
-                        data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
-                        data.npdu_number = Some(buffer[10]);
-                        match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
-                            Ok(i) => data.extension_headers = Some(i),
-                            Err(j) => return Err(j),
-                        }
-                    } else {
-                        return Err(GTPV1Error::HeaderInvalidLength);
-                    }
-                }
-                _ => (),
-            }
-            Ok(data)
-        } else {
-            Err(GTPV1Error::HeaderInvalidLength)
+        if buffer.len() < MIN_HEADER_LENGTH {
+            return Err(GTPV1Error::HeaderInvalidLength)
         }
+        let mut data = Gtpv1Header::default();
+        let gtp_version = buffer[0] >> 5;
+        let gtp_type = (buffer[0] >> 4) & 1;
+        match (gtp_version, gtp_type) {
+            (1, 1) => (),
+            (_, _) => return Err(GTPV1Error::HeaderVersionNotSupported),
+        }
+        data.msgtype = buffer[1];
+        data.length = match u16::from_be_bytes([buffer[2], buffer[3]]) {
+            _l if _l < MIN_HEADER_LENGTH as u16 => return Err(GTPV1Error::HeaderInvalidLength),
+            l => l,
+        };
+        data.teid = u32::from_be_bytes([buffer[4], buffer[5], buffer[6], buffer[7]]);
+        match (
+            (buffer[0] & 0x02) >> 1,
+            buffer[0] & 0x01,
+            (buffer[0] & 0x04) >> 2,
+        ) {
+            (1, 1, 1) => {
+                if buffer[8..].len() < 4 {
+                    return Err(GTPV1Error::HeaderInvalidLength);
+                }
+                data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
+                data.npdu_number = Some(buffer[10]);
+                match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
+                    Ok(i) => data.extension_headers = Some(i),
+                    Err(j) => return Err(j),
+                }
+            }
+            (1, 1, 0) => {
+                if buffer[8..].len() >= 4 {
+                    return Err(GTPV1Error::HeaderInvalidLength);
+                }
+                data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
+                data.npdu_number = Some(buffer[10]);
+                data.extension_headers = None;
+            }
+            (1, 0, 0) => {
+                if buffer[8..].len() >= 4 {
+                    return Err(GTPV1Error::HeaderInvalidLength);
+                }
+                data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
+                data.npdu_number = None;
+                data.extension_headers = None;
+            }
+            (1, 0, 1) => {
+                if buffer[8..].len() < 4 {
+                    return Err(GTPV1Error::HeaderInvalidLength);
+                }
+                data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
+                data.npdu_number = None;
+                match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
+                    Ok(i) => data.extension_headers = Some(i),
+                    Err(j) => return Err(j),
+                }
+            }
+            (0, 0, 0) => {
+                data.sequence_number = None;
+                data.npdu_number = None;
+                data.extension_headers = None;
+            }
+            (0, 0, 1) => {
+                if buffer[8..].len() < 4 {
+                    return Err(GTPV1Error::HeaderInvalidLength);
+                }
+                data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
+                data.npdu_number = Some(buffer[10]);
+                match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
+                    Ok(i) => data.extension_headers = Some(i),
+                    Err(j) => return Err(j),
+                }
+            }
+            (0, 1, 1) => {
+                if buffer[8..].len() < 4 {
+                    return Err(GTPV1Error::HeaderInvalidLength);
+                }
+                data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
+                data.npdu_number = Some(buffer[10]);
+                match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
+                    Ok(i) => data.extension_headers = Some(i),
+                    Err(j) => return Err(j),
+                }
+            }
+            (0, 1, 0) => {
+                if buffer[8..].len() < 4 {
+                    return Err(GTPV1Error::HeaderInvalidLength);
+                }
+                data.sequence_number = Some(u16::from_be_bytes([buffer[8], buffer[9]]));
+                data.npdu_number = Some(buffer[10]);
+                match Gtpv1Header::unmarshal_ext_hdr(&buffer[11..]) {
+                    Ok(i) => data.extension_headers = Some(i),
+                    Err(j) => return Err(j),
+                }
+            }
+            _ => (),
+        }
+        Ok(data)
     }
 
     // Struct helper functions

--- a/src/gtpv1/gtpc/header.rs
+++ b/src/gtpv1/gtpc/header.rs
@@ -144,12 +144,10 @@ impl Gtpv1Header {
 
         data.msgtype = buffer[1];
 
-        // the length field indicates the size of the payload (including the header & extensions) in bytes
+        // indicates the size of the payload, including optional parts of the header
         data.length = u16::from_be_bytes([buffer[2], buffer[3]]);
-        if data.length < MIN_HEADER_LENGTH as u16 {
-            return Err(GTPV1Error::HeaderInvalidLength);
-        }
 
+        // unambiguously identifies a tunnel endpoint
         data.teid = u32::from_be_bytes([buffer[4], buffer[5], buffer[6], buffer[7]]);
 
         // flags indicate only the required fields are provided, so we can return


### PR DESCRIPTION
I've replaced two of the big match cases with more sequential flag parsing (really the only benefit of the match is the catch-all at the end).
While doing that I discovered the reason for a few of the failing tests from #4. We need not compare the length field with the minimal header length, as the spec defines it to be the payload length, following all mandatory fields.