### PR TITLE
Relax Teardown Ind decoding to ignore spare bits

### DIFF
--- a/src/gtpv1/gtpc/messages/ies/teardownind.rs
+++ b/src/gtpv1/gtpc/messages/ies/teardownind.rs
@@ -8,6 +8,9 @@ pub const TEARDOWN_IND: u8 = 19;
 pub const TEARDOWN_IND_LENGTH: u16 = 1;
 
 // Teardown Ind IE implementation
+//
+// Octet 2: LSB is Teardown Ind, upper 7 bits are spare. Encoding sets the
+// spare bits to '1' per Figure 24; decoding treats them as don't-care.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TeardownInd {
@@ -36,11 +39,7 @@ impl IEs for TeardownInd {
     fn unmarshal(buffer: &[u8]) -> Result<Self, GTPV1Error> {
         if buffer.len() >= (TEARDOWN_IND_LENGTH + 1) as usize {
             let data = TeardownInd {
-                teardown: match buffer[1] {
-                    0xfe => false,
-                    0xff => true,
-                    _ => return Err(GTPV1Error::IEIncorrect),
-                },
+                teardown: (buffer[1] & 0x01) != 0,
                 ..Default::default()
             };
             Ok(data)
@@ -78,4 +77,14 @@ fn teardown_ind_ie_marshal_test() {
     let mut buffer: Vec<u8> = vec![];
     test_struct.marshal(&mut buffer);
     assert_eq!(buffer, encoded_ie);
+}
+
+// Spare bits are ignored on decode; only the LSB determines the value.
+#[test]
+fn teardown_ind_ie_unmarshal_spare_bits_ignored_test() {
+    for (octet, expected) in [(0x00, false), (0x01, true), (0xaa, false), (0x55, true)] {
+        let encoded_ie: [u8; 2] = [0x13, octet];
+        let decoded = TeardownInd::unmarshal(&encoded_ie).unwrap();
+        assert_eq!(decoded.teardown, expected, "octet 0x{:02x}", octet);
+    }
 }


### PR DESCRIPTION
Per clause 7.7.16 of 3GPP TS 29.060, the Teardown Ind IE places the Teardown Ind value in the LSB of octet 2, with the upper 7 bits marked as spare. Figure 24 / Table 43 depict the spare bits as '1', and the current implementation enforces this on decode by accepting only `0xfe` (No) or `0xff` (Yes); anything else is rejected as `IEIncorrect`.

In practice, a small number of GTP node implementations transmit the spare bits as '0' (e.g. encoding "Yes" as `0x01`). The strict decoder rejects these messages even though the LSB unambiguously conveys the Teardown Ind value.

Clause 7.7.16 itself is silent on how the spare bits must be set.
However, the analogous wording in clause 7.7.15 (Tunnel Endpoint Identifier Data II) states:

> The spare bits x indicate unused bits, which shall be set to 0 by the sending side and which shall not be evaluated by the receiving side.

This reflects the robustness principle the spec applies consistently: encode strictly, decode leniently. Applying the same principle to the Teardown Ind IE:

- **Encoding** stays aligned with Figure 24 — spare bits are set to '1', so `marshal` continues to emit `0xfe` / `0xff`.
- **Decoding** now treats the spare bits as don't-care and inspects only the LSB.

This restores interoperability with peers that send cleared spare bits, without changing what this library transmits on the wire.

## Changes

- `src/gtpv1/gtpc/messages/ies/teardownind.rs`
  - `unmarshal` now decodes via `(buffer[1] & 0x01) != 0` instead of matching the full octet against `0xfe` / `0xff`.
  - `marshal` unchanged.
  - Added a short implementation note about the encode-strict / decode-lenient policy.
  - Added a unit test covering spare-bit patterns `0x00`, `0x01`, `0xaa`, `0x55`.